### PR TITLE
update table check to upgrade_table

### DIFF
--- a/buildstock_query/main.py
+++ b/buildstock_query/main.py
@@ -129,7 +129,7 @@ class BuildStockQuery(QueryCore):
     @validate_arguments
     def _get_rows_per_building(self, get_query_only: bool = False) -> Union[int, str]:
         select_cols = []
-        if self.ts_table is not None:
+        if self.up_table is not None:
             select_cols.append(self.ts_table.c['upgrade'])
         select_cols.extend((self.ts_bldgid_column, safunc.count().label("row_count")))
         ts_query = sa.select(select_cols)


### PR DESCRIPTION
Resolves #[issue number here].

Current code would err out for a baseline-only run (e.g., `"resstock-core"."2023-03-17-national-baseline-full"` ) during initialization with the following error. The error is due to `self.ts_table.c['upgrade']` being empty when `self.up_table` does not exist. So the if statement should be checking for up_table instead of ts_table (which always exists).
```
---------------------------------------------------------------------------
OperationalError                          Traceback (most recent call last)
Cell In[2], line 5
      3 table = "2023-03-17-national-baseline-full"
      4 workgroup = "rescore"
----> 5 bsq = BuildStockQuery(db_name=database,
      6                       table_name=table,
      7                       workgroup=workgroup,
      8                       buildstock_type='resstock')

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:40](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:40), in pydantic.decorator.validate_arguments.validate.wrapper_function()

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:134](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:134), in pydantic.decorator.ValidatedFunction.call()

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:206](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:206), in pydantic.decorator.ValidatedFunction.execute()

File [~/Documents/GitHub/buildstock-query/buildstock_query/main.py:87](https://file+.vscode-resource.vscode-cdn.net/Users/lliu2/Documents/GitHub/resstock-analysis/visualization/~/Documents/GitHub/buildstock-query/buildstock_query/main.py:87), in BuildStockQuery.__init__(self, workgroup, db_name, table_name, buildstock_type, timestamp_column_name, building_id_column_name, sample_weight, region_name, execution_history, skip_reports)
     85 print(self.report.get_success_report())
     86 if self.ts_table is not None:
---> 87     self.report.check_ts_bs_integrity()
     88 self.save_cache()

File [~/Documents/GitHub/buildstock-query/buildstock_query/report_query.py:581](https://file+.vscode-resource.vscode-cdn.net/Users/lliu2/Documents/GitHub/resstock-analysis/visualization/~/Documents/GitHub/buildstock-query/buildstock_query/report_query.py:581), in BuildStockReport.check_ts_bs_integrity(self)
    579     print_g("Annual and timeseries tables are verified to have the same number of buildings.")
    580 try:
--> 581     rowcount = self._bsq._get_rows_per_building()
    582     print_g(f"All buildings are verified to have the same number of ({rowcount}) timeseries rows.")
    583 except ValueError:

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:40](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:40), in pydantic.decorator.validate_arguments.validate.wrapper_function()

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:134](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:134), in pydantic.decorator.ValidatedFunction.call()

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:206](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:206), in pydantic.decorator.ValidatedFunction.execute()

File [~/Documents/GitHub/buildstock-query/buildstock_query/main.py:143](https://file+.vscode-resource.vscode-cdn.net/Users/lliu2/Documents/GitHub/resstock-analysis/visualization/~/Documents/GitHub/buildstock-query/buildstock_query/main.py:143), in BuildStockQuery._get_rows_per_building(self, get_query_only)
    141 if get_query_only:
    142     return self._compile(ts_query)
--> 143 df = self.execute(ts_query)
    144 if (df['row_count'] == df['row_count'][0]).all():  # verify all buildings got same number of rows
    145     return df['row_count'][0]

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:40](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:40), in pydantic.decorator.validate_arguments.validate.wrapper_function()

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:134](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:134), in pydantic.decorator.ValidatedFunction.call()

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:206](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pydantic/decorator.py:206), in pydantic.decorator.ValidatedFunction.execute()

File [~/Documents/GitHub/buildstock-query/buildstock_query/query_core.py:464](https://file+.vscode-resource.vscode-cdn.net/Users/lliu2/Documents/GitHub/resstock-analysis/visualization/~/Documents/GitHub/buildstock-query/buildstock_query/query_core.py:464), in QueryCore.execute(self, query, run_async)
    462 else:
    463     if query not in self._query_cache:
--> 464         self._query_cache[query] = self._conn.cursor().execute(query,
    465                                                                result_reuse_enable=True,
    466                                                                result_reuse_minutes=60 * 24 * 7,
    467                                                                ).as_pandas()
    468     return self._query_cache[query].copy()

File [/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pyathena/pandas/cursor.py:192](https://file+.vscode-resource.vscode-cdn.net/opt/anaconda3/envs/bsb-query/lib/python3.11/site-packages/pyathena/pandas/cursor.py:192), in PandasCursor.execute(self, operation, parameters, work_group, s3_staging_dir, cache_size, cache_expiration_time, result_reuse_enable, result_reuse_minutes, keep_default_na, na_values, quoting, **kwargs)
    173     self.result_set = AthenaPandasResultSet(
    174         connection=self._connection,
    175         converter=self._converter,
   (...)
    189         **kwargs,
    190     )
    191 else:
--> 192     raise OperationalError(query_execution.state_change_reason)
    193 return self

OperationalError: EXPRESSION_NOT_AGGREGATE: line 1:64: '"2023-03-17-national-baseline-full_timeseries".building_id' must be an aggregate expression or appear in GROUP BY clause
```

## Pull Request Description

See above
