### PR TITLE
Parameter overlap report

### DIFF
--- a/buildstock_query/tools/upgrades_analyzer.py
+++ b/buildstock_query/tools/upgrades_analyzer.py
@@ -892,6 +892,74 @@ class UpgradesAnalyzer:
             return full_set
         return minimal_buildings
 
+    def get_parameter_overlap_report(self, report_df: pd.DataFrame):
+        """
+        Check if any parameter (like "HVAC Heating Efficiency") is applied multiple times (via multiple options) to
+        the same building within the same upgrade. If any such case is found, return a report with the details.
+        """
+        report_df["parameter"] = report_df["option"].str.partition("|")[0]
+        # down select to parameters that appear more than once per upgrade in the report
+        param_count_df = report_df.groupby(["upgrade", "parameter"]).size().to_frame(name="count")
+        param_count_df = param_count_df[param_count_df["count"] > 1]
+        if param_count_df.empty:
+            return
+        filtered_report_df = param_count_df.join(report_df.set_index(["upgrade", "parameter"])).reset_index()
+        filtered_report_df["bldg_count"] = filtered_report_df["applicable_buildings"].apply(lambda x: len(x))
+
+        # down select to parameters that applies to at least one building more than once
+        # i.e. size of set-union of applicable buildings is not equal to sum of applicable buildings
+        union_df = filtered_report_df.groupby(["upgrade", "parameter"]).agg(
+            {"applicable_buildings": lambda x: set.union(*x), "bldg_count": "sum"}
+        )
+        union_df["union_count"] = union_df["applicable_buildings"].apply(lambda x: len(x))
+        problem_param_df = union_df[union_df["union_count"] != union_df["bldg_count"]]
+
+        if problem_param_df.empty:
+            return ""
+
+        overlap_report_text = ""
+        # Using the original report_df for these upgrade and parameter, sequentially for each option for those parameter,
+        # list the other options it overlaps with along with example buildings
+        for (upgrade, parameter), row in problem_param_df.iterrows():
+            overlap_report_text += f"Parameter '{parameter}' in upgrade '{upgrade}' has overlapping applications\n"
+            options = filtered_report_df[
+                (filtered_report_df["upgrade"] == upgrade) & (filtered_report_df["parameter"] == parameter)
+            ]
+
+            # Use combinations to avoid checking both A->B and B->A
+            for i, j in combinations(options.index, 2):
+                option_row = options.loc[i]
+                other_row = options.loc[j]
+
+                option = f"Option {option_row['option_num']}:{option_row['option']}"
+                other_option = f"Option {other_row['option_num']}:{other_row['option']}"
+
+                option_bldgs = option_row["applicable_buildings"]
+                other_bldgs = other_row["applicable_buildings"]
+
+                overlap = option_bldgs.intersection(other_bldgs)
+                assert overlap, (
+                    f"No overlap found between {option} and {other_option} although they should have overlapped based on problem_df"
+                )
+                example_bldgs = list(overlap)[:5]  # Show up to 5 example buildings
+                overlap_report_text += f"{option} overlaps with {other_option} on {len(overlap)} buildings\n"
+                overlap_report_text += f"Example buildings: {example_bldgs}\n"
+                upgrade_cfg = self.cfg["upgrades"][option_row["upgrade"] - 1]
+                option_cfg = upgrade_cfg["options"][option_row["option_num"] - 1]
+                other_option_cfg = upgrade_cfg["options"][other_row["option_num"] - 1]
+                parameter_list = []
+                parameter_list.append(UpgradesAnalyzer._get_para_option(option_cfg["option"])[0])
+                parameter_list.extend(UpgradesAnalyzer.get_mentioned_parameters(option_cfg.get("apply_logic")))
+                parameter_list.extend(UpgradesAnalyzer.get_mentioned_parameters(other_option_cfg.get("apply_logic")))
+                parameter_list.extend(UpgradesAnalyzer.get_mentioned_parameters(upgrade_cfg.get("package_apply_logic")))
+                parameter_list = list(set(parameter_list))
+                example_buildstock_df = self.buildstock_df.loc[example_bldgs][parameter_list]
+                overlap_report_text += tabulate(example_buildstock_df, headers="keys", tablefmt="grid", maxcolwidths=50)
+                overlap_report_text += "\n"
+        if overlap_report_text:
+            Path("parameter_overlap_report.txt").write_text(overlap_report_text)
+        return overlap_report_text
+
 
 def main():
     import argparse
@@ -953,6 +1021,16 @@ def main():
     folder_path = Path.cwd()
     csv_name = folder_path / f"{output_prefix}option_application_report.csv"
     txt_name = folder_path / f"{output_prefix}option_application_detailed_report.txt"
+    param_overlap_path = folder_path / f"{output_prefix}parameter_overlap_report.txt"
+    print("Checking for parameter overlap...")
+    param_overlap_report = ua.get_parameter_overlap_report(report_df)
+    if param_overlap_report:
+        print("Some parameters are applied multiple times to the same building within the same upgrade.")
+        print(f"Please check the {param_overlap_path} file for details.")
+        param_overlap_path.write_text(param_overlap_report)
+    else:
+        print("All good! No parameter applies multiple times in the same upgrade.")
+
     buildstock_name = folder_path / f"{output_prefix}minimal_buildstock.csv"
     minimal_bldgs = ua.get_minimal_representative_buildings(
         report_df["applicable_buildings"].to_list(), include_never_upgraded=True, verbose=True

--- a/buildstock_query/tools/upgrades_analyzer.py
+++ b/buildstock_query/tools/upgrades_analyzer.py
@@ -902,7 +902,7 @@ class UpgradesAnalyzer:
         param_count_df = report_df.groupby(["upgrade", "parameter"]).size().to_frame(name="count")
         param_count_df = param_count_df[param_count_df["count"] > 1]
         if param_count_df.empty:
-            return
+            return ""
         filtered_report_df = param_count_df.join(report_df.set_index(["upgrade", "parameter"])).reset_index()
         filtered_report_df["bldg_count"] = filtered_report_df["applicable_buildings"].apply(lambda x: len(x))
 

--- a/buildstock_query/tools/upgrades_analyzer.py
+++ b/buildstock_query/tools/upgrades_analyzer.py
@@ -918,8 +918,8 @@ class UpgradesAnalyzer:
             return ""
 
         overlap_report_text = ""
-        # Using the original report_df for these upgrade and parameter, sequentially for each option for those parameter,
-        # list the other options it overlaps with along with example buildings
+
+        # Generate the detailed overlap report table
         for (upgrade, parameter), row in problem_param_df.iterrows():
             overlap_report_text += f"Parameter '{parameter}' in upgrade '{upgrade}' has overlapping applications\n"
             options = filtered_report_df[
@@ -939,11 +939,15 @@ class UpgradesAnalyzer:
 
                 overlap = option_bldgs.intersection(other_bldgs)
                 assert overlap, (
-                    f"No overlap found between {option} and {other_option} although they should have overlapped based on problem_df"
+                    f"No overlap found between {option} and {other_option} although "
+                    "they should have overlapped based on problem_df"
                 )
                 example_bldgs = list(overlap)[:5]  # Show up to 5 example buildings
                 overlap_report_text += f"{option} overlaps with {other_option} on {len(overlap)} buildings\n"
                 overlap_report_text += f"Example buildings: {example_bldgs}\n"
+
+                # Show the subset of buildstock_df using the example overlap buildings
+                # and the relevant columns used in the apply logics
                 upgrade_cfg = self.cfg["upgrades"][option_row["upgrade"] - 1]
                 option_cfg = upgrade_cfg["options"][option_row["option_num"] - 1]
                 other_option_cfg = upgrade_cfg["options"][other_row["option_num"] - 1]

--- a/tests/test_UpgradeAnalyzer.py
+++ b/tests/test_UpgradeAnalyzer.py
@@ -3,19 +3,19 @@ import numpy as np
 from buildstock_query.tools import UpgradesAnalyzer
 import pytest
 import pandas as pd
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 class TestUpgradesAnalyzer:
-
     # Create three different kind of UpgradesAnalyzer fixuture objects.
     # 1. with_filter: upgrades yaml and filter yaml are included
     # 2. without_filter: only upgrades yaml is included
     # 3. only_filter: only filter yaml is included
     # The test cases are parametrized to run with all three kinds of fixtures.
     # But some test functions skip the test if the fixture is not applicable.
-    @pytest.fixture(params=['with_filter', 'without_filter', 'only_filter'],
-                    ids=["with_filter", "without_filter", "only_filter"])
+    @pytest.fixture(
+        params=["with_filter", "without_filter", "only_filter"], ids=["with_filter", "without_filter", "only_filter"]
+    )
     def ua(self, request):
         folder_path = pathlib.Path(__file__).parent.resolve()
 
@@ -36,11 +36,13 @@ class TestUpgradesAnalyzer:
 
         self.buildstock_path = folder_path / "reference_files" / "res_n250_15min_v19_buildstock.csv"
         self.opt_sat_path = folder_path / "reference_files" / "options_saturations.csv"
-        ua = UpgradesAnalyzer(yaml_file=yaml_path,
-                              filter_yaml_file=filter_yaml_path,
-                              buildstock=str(self.buildstock_path),
-                              upgrade_names=upgrade_names,
-                              opt_sat_file=str(self.opt_sat_path))
+        ua = UpgradesAnalyzer(
+            yaml_file=yaml_path,
+            filter_yaml_file=filter_yaml_path,
+            buildstock=str(self.buildstock_path),
+            upgrade_names=upgrade_names,
+            opt_sat_file=str(self.opt_sat_path),
+        )
         return ua
 
     def test_read_cfg(self, ua, request):
@@ -84,7 +86,6 @@ class TestUpgradesAnalyzer:
         assert expected_output == UpgradesAnalyzer._get_eq_str(test_inp)
 
     def test_get_mentioned_parameters(self):
-
         empty_logics = [{}, [], "", None]
         for logic in empty_logics:
             assert UpgradesAnalyzer.get_mentioned_parameters(logic) == []
@@ -139,9 +140,9 @@ class TestUpgradesAnalyzer:
 
     def test_normalize_lists(self):
         logic = [["logic1", "logic2"], ["logic3", "logic4"]]
-        flatened_logic = UpgradesAnalyzer._normalize_lists(logic)
+        flattened_logic = UpgradesAnalyzer._normalize_lists(logic)
         expected_logic = {"and": [{"and": ["logic1", "logic2"]}, {"and": ["logic3", "logic4"]}]}
-        assert flatened_logic == expected_logic
+        assert flattened_logic == expected_logic
 
         logic = {
             "or": [
@@ -151,7 +152,7 @@ class TestUpgradesAnalyzer:
                 ["logic7"],
             ]
         }
-        flatened_logic = UpgradesAnalyzer._normalize_lists(logic)
+        flattened_logic = UpgradesAnalyzer._normalize_lists(logic)
         expected_logic = {
             "or": [
                 {"and": ["logic1", "logic2"]},
@@ -160,7 +161,7 @@ class TestUpgradesAnalyzer:
                 "logic7",
             ]
         }
-        assert expected_logic == flatened_logic
+        assert expected_logic == flattened_logic
 
         logic = {
             "and": [
@@ -168,9 +169,9 @@ class TestUpgradesAnalyzer:
                 {"and": ["Vintage|1980s", "Vintage|1960s"]},
             ]
         }
-        flatened_logic = UpgradesAnalyzer._normalize_lists(logic)
+        flattened_logic = UpgradesAnalyzer._normalize_lists(logic)
         expected_logic = logic.copy()
-        assert flatened_logic == expected_logic
+        assert flattened_logic == expected_logic
 
     def test_print_options_application_report(self, ua: UpgradesAnalyzer, capsys):
         logic_dict = {
@@ -181,21 +182,21 @@ class TestUpgradesAnalyzer:
         }  # {"opt_index": logic_array_of_applicable_buildings}
         report_df = ua._get_options_application_count_report(logic_dict)
         assert len(report_df) == 3
-        assert report_df.loc[2]['Applied buildings'] == '1 (33.3%)'
-        assert report_df.loc[2]['Cumulative all'] == '1 (33.3%)'
-        assert report_df.loc[3]['Applied options'].iloc[0] == "1, 2, 3"
-        assert report_df.loc[3]['Applied options'].iloc[1] == "1, 2, 4"
-        assert report_df.loc[3]['Applied buildings'].iloc[0] == "1 (33.3%)"
-        assert report_df.loc[3]['Applied buildings'].iloc[1] == "1 (33.3%)"
-        assert report_df.loc[3]['Cumulative all'].iloc[0] == "2 (66.7%)"
-        assert report_df.loc[3]['Cumulative all'].iloc[1] == "3 (100.0%)"
+        assert report_df.loc[2]["Applied buildings"] == "1 (33.3%)"
+        assert report_df.loc[2]["Cumulative all"] == "1 (33.3%)"
+        assert report_df.loc[3]["Applied options"].iloc[0] == "1, 2, 3"
+        assert report_df.loc[3]["Applied options"].iloc[1] == "1, 2, 4"
+        assert report_df.loc[3]["Applied buildings"].iloc[0] == "1 (33.3%)"
+        assert report_df.loc[3]["Applied buildings"].iloc[1] == "1 (33.3%)"
+        assert report_df.loc[3]["Cumulative all"].iloc[0] == "2 (66.7%)"
+        assert report_df.loc[3]["Cumulative all"].iloc[1] == "3 (100.0%)"
 
     def test_get_report_only_filter(self, ua: UpgradesAnalyzer, request):
         if request.node.callspec.id != "only_filter":
             return
         report = ua.get_report()
         assert len(report) == 8
-        assert (list(report['removal_count'].values) == [14, 36, 14, 14, 14, 14, 14, 14])
+        assert list(report["removal_count"].values) == [14, 36, 14, 14, 14, 14, 14, 14]
 
     def test_get_report(self, ua: UpgradesAnalyzer, request):
         if request.node.callspec.id == "only_filter":  # test if upgrades yaml is included
@@ -241,7 +242,7 @@ class TestUpgradesAnalyzer:
         logic_cond3_3 = ua.buildstock_df["location region"] == "CR09"
         opt3_logic = (logic_cond3_1 | logic_cond3_2) & logic_cond3_3 & pkg_logic
         if ua.filter_cfg:
-            remove_logic = ((ua.buildstock_df["vintage"] == "1980s") | (ua.buildstock_df["vintage"] == "1960s"))
+            remove_logic = (ua.buildstock_df["vintage"] == "1980s") | (ua.buildstock_df["vintage"] == "1960s")
             opt1_logic &= ~remove_logic
             opt2_logic &= ~remove_logic
             opt3_logic &= ~remove_logic
@@ -259,7 +260,7 @@ class TestUpgradesAnalyzer:
         assert len(report_df) == 2
         opt1_cond = report_df["option"] == "Vintage|1980s"
         if ua.filter_cfg:
-            remove_logic = ((ua.buildstock_df["vintage"] == "1980s"))
+            remove_logic = ua.buildstock_df["vintage"] == "1980s"
             total_applicable_buildings = sum(~remove_logic)
             assert report_df[report_df["option"] == "All"].removal_count.values[0] == sum(remove_logic)
         else:
@@ -309,12 +310,12 @@ class TestUpgradesAnalyzer:
         assert opt2_text in report_text
         assert opt3_text in report_text
 
-        substr1 = report_text[report_text.index(opt1_text): report_text.index(opt2_text)]
+        substr1 = report_text[report_text.index(opt1_text) : report_text.index(opt2_text)]
         assert "Package Apply Logic Report" in substr1
         if ua.filter_cfg:  # if filter yaml is included
-            package_report = substr1[substr1.index("Package Apply Logic Report"):substr1.index("Remove Logic Report")]
+            package_report = substr1[substr1.index("Package Apply Logic Report") : substr1.index("Remove Logic Report")]
         else:
-            package_report = substr1[substr1.index("Package Apply Logic Report"):]
+            package_report = substr1[substr1.index("Package Apply Logic Report") :]
         main_report = substr1[: substr1.index("Package Apply Logic Report")]
         logic_opt1_1 = ua.buildstock_df["windows"] == "Single, Clear, Metal"
         assert f"Windows|Single, Clear, Metal => {sum(logic_opt1_1)}" in main_report
@@ -335,8 +336,8 @@ class TestUpgradesAnalyzer:
 
         if ua.filter_cfg:  # if filter yaml is included
             assert "Remove Logic Report" in substr1
-            remove_report = substr1[substr1.index("Remove Logic Report"):]
-            remove_logic = ((ua.buildstock_df["vintage"] == "1980s") | (ua.buildstock_df["vintage"] == "1960s"))
+            remove_report = substr1[substr1.index("Remove Logic Report") :]
+            remove_logic = (ua.buildstock_df["vintage"] == "1980s") | (ua.buildstock_df["vintage"] == "1960s")
             assert f"or => {sum(remove_logic)}" in remove_report
             assert f"Vintage|1980s => {sum(ua.buildstock_df['vintage'] == '1980s')}" in remove_report
             assert f"Vintage|1960s => {sum(ua.buildstock_df['vintage'] == '1960s')}" in remove_report
@@ -349,12 +350,12 @@ class TestUpgradesAnalyzer:
 
         # verify opt_app_report_df
         if ua.filter_cfg:
-            assert opt_app_report_df["Applied options"].to_list() == ['windows']
-            assert opt_app_report_df["Applied buildings"].str.split(" ").str[0].to_list() == ['28']
+            assert opt_app_report_df["Applied options"].to_list() == ["windows"]
+            assert opt_app_report_df["Applied buildings"].str.split(" ").str[0].to_list() == ["28"]
         else:
-            assert opt_app_report_df["Applied options"].to_list() == ['windows', 'vintage', 'windows, vintage']
-            assert opt_app_report_df["Applied buildings"].str.split(" ").str[0].to_list() == ['29', '20', '9']
-        
+            assert opt_app_report_df["Applied options"].to_list() == ["windows", "vintage", "windows, vintage"]
+            assert opt_app_report_df["Applied buildings"].str.split(" ").str[0].to_list() == ["29", "20", "9"]
+
         # verify opt_app_detailed_report_df
         for indx, row in opt_app_detailed_report_df.iterrows():
             applied_bldgs_array = np.ones((1, ua.total_samples), dtype=bool)
@@ -503,18 +504,18 @@ class TestUpgradesAnalyzer:
                 n_unchanged = len(df_same.query(query)[dimensions])
                 n_diff = abs(n_diff)
                 assert n_diff == n_unchanged, (
-                    f"Only {n_unchanged} dwelling units were found to be unchanged, " f"expecting {n_diff} per report"
+                    f"Only {n_unchanged} dwelling units were found to be unchanged, expecting {n_diff} per report"
                 )
 
     def test_get_minimal_representative_buildings(self):
         # Create mock UpgradesAnalyzer instance
         mock_buildstock_df = pd.DataFrame(index=list(range(1, 11)))  # 1 to 10
-        
+
         # Create the analyzer with just the necessary components for this test
-        with patch.object(UpgradesAnalyzer, '__init__', return_value=None):
+        with patch.object(UpgradesAnalyzer, "__init__", return_value=None):
             ua = UpgradesAnalyzer()
             ua.buildstock_df = mock_buildstock_df
-        
+
         # Test case: Basic functionality
         building_groups = [
             {1, 2, 3},  # Group 1
@@ -523,20 +524,20 @@ class TestUpgradesAnalyzer:
             {6, 7, 8},  # Group 4
             {1, 8, 9},  # Group 5
         ]
-        
+
         minimal_set = ua.get_minimal_representative_buildings(building_groups, include_never_upgraded=True)
         assert isinstance(minimal_set, list)
         assert minimal_set == [8, 5, 3, 10]
         assert [8, 5, 3] == ua.get_minimal_representative_buildings(building_groups)
-        
+
         # Test case: Empty input
         assert ua.get_minimal_representative_buildings([]) == []
         assert ua.get_minimal_representative_buildings([], include_never_upgraded=True) == [10]
-        
+
         # Test case: Input with empty sets (should be ignored)
         building_groups_with_empty = [set(), {1, 2}, set(), {3, 4}]
         assert [4, 2] == ua.get_minimal_representative_buildings(building_groups_with_empty)
-        
+
         # Test case 4: Disjoint sets requiring multiple buildings
         disjoint_groups = [
             {1, 2},
@@ -546,7 +547,7 @@ class TestUpgradesAnalyzer:
             {9, 10},
         ]
         assert [10, 8, 6, 4, 2] == ua.get_minimal_representative_buildings(disjoint_groups)
-        
+
         # Test case where greedy algorithm is not optimal
         building_groups = [
             {1, 10, 4},
@@ -558,3 +559,13 @@ class TestUpgradesAnalyzer:
         ]
         # optimal solution is [2, 1].
         assert [4, 2, 1] == ua.get_minimal_representative_buildings(building_groups)
+
+    def test_check_parameter_overlap(self, ua: UpgradesAnalyzer, request):
+        if request.node.callspec.id == "only_filter":  # test if upgrades yaml is included
+            return
+        report_df = ua.get_report()
+        overlap_text = ua.get_parameter_overlap_report(report_df)
+        if ua.filter_cfg:
+            assert overlap_text == ""
+        else:
+            assert "Option 2:Vintage|1980s overlaps with Option 3:Vintage|1970s on 12 buildings" in overlap_text


### PR DESCRIPTION
Resolves #[issue number here].

## Pull Request Description

The upgrades analyzer will catch with the same parameter is applied multiple times within the same upgrade (for example a particular building gets applied both the `Windows|Triple, Low-E, Insulated, Argon, H-Gain` and `Windows|Single, Clear, Metal, Exterior Low-E Storm`). While ResStock is fine with this and will honor the later option, this is usually a error in the apply logic definition. The PR will generate warnings and overlap report to catch this error and help debug it.

Example overlap report beflow
```
Parameter 'Infiltration' in upgrade '2' has overlapping application
Option 2:Infiltration|1 ACH50 overlaps with Option 3:Infiltration|5 ACH50 on 12 buildings
Example buildings: ['58', '146', '179', '1', '161']
+---------------+-----------+-------------------+
|   building_id | vintage   | location region   |
+===============+===========+===================+
|            58 | 1960s     | CR09              |
+---------------+-----------+-------------------+
|           146 | 1960s     | CR09              |
+---------------+-----------+-------------------+
|           179 | 1960s     | CR09              |
+---------------+-----------+-------------------+
|             1 | 1960s     | CR09              |
+---------------+-----------+-------------------+
|           161 | 1960s     | CR09              |
+---------------+-----------+-------------------+
```
