### PR TITLE
[codex] Preserve restricts without upgrades

### DIFF
--- a/buildstock_query/aggregate_query.py
+++ b/buildstock_query/aggregate_query.py
@@ -42,7 +42,13 @@ class BuildStockAggregate:
         if upgrade_id == "0":
             # For baseline, return original tables with group_by as-is
             if self._bsq.up_table is None:  # There are no upgrades so just return the timeseries table as is
-                tbljoin = ts.join(base, self._bsq.bs_bldgid_column == self._bsq.ts_bldgid_column)
+                tbljoin = ts.join(
+                    base,
+                    sa.and_(
+                        self._bsq.bs_bldgid_column == self._bsq.ts_bldgid_column,
+                        *self._bsq._get_restrict_clauses(restrict, annual_only=True),
+                    ),
+                )
             else:
                 tbljoin = ts.join(
                     base,

--- a/tests/test_BuildStockQuery.py
+++ b/tests/test_BuildStockQuery.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-import pandas as pd
-import pytest
 import ast
 from typing import Generator
+
+import pandas as pd
+import pytest
+import sqlalchemy as sa
+
 from buildstock_query.main import BuildStockQuery
 from buildstock_query.schema.query_params import Query, BaseQuery
 
@@ -153,6 +156,51 @@ class TestBuildStockQuery:
         assert {"geometry_building_type_recs", "state", "time"} <= set(df.columns)
         assert (df["state"] == "TX").all()
         assert df["fuel_use__electricity__total__kwh"].ge(0).all()
+
+    def test_timeseries_query_keeps_ts_restrict_without_upgrades(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        table_name = "small_run_baseline_20230810_100"
+
+        metadata = sa.MetaData()
+        baseline = sa.Table(
+            f"{table_name}_baseline",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("completed_status", sa.String),
+        )
+        timeseries = sa.Table(
+            f"{table_name}_timeseries",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("time", sa.DateTime),
+            sa.Column("upgrade", sa.String),
+            sa.Column("fuel_use__electricity__total__kwh", sa.Float),
+        )
+
+        def _get_local_tables(self, requested_table_name):
+            assert requested_table_name == table_name
+            return baseline, timeseries, None
+
+        monkeypatch.setattr(BuildStockQuery, "_get_tables", _get_local_tables)
+        bsq = BuildStockQuery(
+            db_name="resstock_core",
+            table_name=table_name,
+            workgroup="rescore",
+            buildstock_type="resstock",
+            skip_reports=True,
+            sample_weight_override=1,
+        )
+        monkeypatch.setattr(bsq, "get_available_upgrades", lambda: ["0"])
+
+        query = bsq.query(
+            annual_only=False,
+            enduses=["fuel_use__electricity__total__kwh"],
+            restrict=[(bsq.building_id_column_name, [1])],
+            get_query_only=True,
+        )
+
+        assert f"{bsq.ts_table.name}.{bsq.building_id_column_name} = 1" in query
 
     def test_timeseries_matches_query(self, bsq: BuildStockQuery) -> None:
         agg_df = bsq.agg.aggregate_timeseries(


### PR DESCRIPTION
## Summary
- preserve timeseries restrict clauses on the baseline join when a run has no upgrades
- add a regression test covering the no-upgrades branch with compiled SQL

## Root Cause

`BuildStockAggregate.__get_timeseries_bs_up_table()` applied restrict clauses when an upgrades table existed, but skipped them in the baseline path when `up_table` was `None`.

## Impact
Baseline timeseries queries for runs without upgrades now honor restrict filters consistently instead of dropping them from the join path.

## Validation
- `source .venv/bin/activate && pytest -x tests/test_BuildStockQuery.py -k "timeseries_query_keeps_ts_restrict_without_upgrades"`
- `source .venv/bin/activate && python -m py_compile buildstock_query/aggregate_query.py tests/test_BuildStockQuery.py`
