### PR TITLE
Add applied_in query filter

### DIFF
--- a/buildstock_query/aggregate_query.py
+++ b/buildstock_query/aggregate_query.py
@@ -496,6 +496,11 @@ class BuildStockAggregate:
         [self._bsq._get_table(jl[0]) for jl in params.join_list]  # ingress all tables in join list
 
         upgrade_id = self._bsq._validate_upgrade(params.upgrade_id)
+        self._bsq._validate_timeseries_upgrade_restrict(
+            params.restrict,
+            annual_only=params.annual_only,
+            upgrade_id=upgrade_id,
+        )
         bs_restrict = self._bsq._add_applied_in_restrict(
             params.restrict,
             applied_in=params.applied_in,

--- a/buildstock_query/aggregate_query.py
+++ b/buildstock_query/aggregate_query.py
@@ -9,7 +9,7 @@ import pandas as pd
 from buildstock_query.schema.helpers import gather_params
 from typing import Union
 from collections.abc import Sequence
-from buildstock_query.schema.utilities import AnyColType, DBColType, RestrictTuple, validate_arguments
+from buildstock_query.schema.utilities import DBColType, RestrictTuple, validate_arguments
 from pydantic import Field
 
 logging.basicConfig(level=logging.INFO)

--- a/buildstock_query/aggregate_query.py
+++ b/buildstock_query/aggregate_query.py
@@ -9,7 +9,7 @@ import pandas as pd
 from buildstock_query.schema.helpers import gather_params
 from typing import Union
 from collections.abc import Sequence
-from buildstock_query.schema.utilities import AnyColType, DBColType, validate_arguments
+from buildstock_query.schema.utilities import AnyColType, DBColType, RestrictTuple, validate_arguments
 from pydantic import Field
 
 logging.basicConfig(level=logging.INFO)
@@ -29,7 +29,7 @@ class BuildStockAggregate:
         enduses: Sequence[DBColType],
         upgrade_id: str,
         applied_only: bool | None,
-        restrict: Sequence[tuple[AnyColType, Union[str, int, Sequence[Union[int, str]]]]] = Field(default_factory=list),
+        restrict: Sequence[RestrictTuple] = Field(default_factory=list),
         group_by: Sequence[DBColType] = Field(default_factory=list),
     ):
         if self._bsq.ts_table is None:
@@ -496,6 +496,11 @@ class BuildStockAggregate:
         [self._bsq._get_table(jl[0]) for jl in params.join_list]  # ingress all tables in join list
 
         upgrade_id = self._bsq._validate_upgrade(params.upgrade_id)
+        bs_restrict = self._bsq._add_applied_in_restrict(
+            params.restrict,
+            applied_in=params.applied_in,
+            annual_only=params.annual_only,
+        )
         enduse_cols = self._bsq._get_enduse_cols(
             params.enduses, table="baseline" if params.annual_only else "timeseries"
         )
@@ -511,7 +516,7 @@ class BuildStockAggregate:
         if params.annual_only:
             bs_tbl, up_tbl, tbljoin = self.__get_annual_bs_up_table(upgrade_id, params.applied_only)
         else:
-            params.restrict, ts_restrict = self._bsq._split_restrict(params.restrict)
+            bs_restrict, ts_restrict = self._bsq._split_restrict(bs_restrict)
             bs_tbl, up_tbl, tbljoin, group_by_selection = self.__get_timeseries_bs_up_table(
                 enduse_cols, upgrade_id, params.applied_only, ts_restrict, group_by_selection
             )
@@ -692,7 +697,7 @@ class BuildStockAggregate:
         query = self._bsq._add_join(query, params.join_list)
         if params.annual_only:
             query = query.where(self._bsq._bs_successful_condition)
-        query = self._bsq._add_restrict(query, params.restrict)
+        query = self._bsq._add_restrict(query, bs_restrict)
         query = self._bsq._add_avoid(query, params.avoid, annual_only=params.annual_only)
         query = self._bsq._add_group_by(query, group_by_selection)
         query = self._bsq._add_order_by(query, group_by_selection if params.sort else [])

--- a/buildstock_query/aggregate_query.pyi
+++ b/buildstock_query/aggregate_query.pyi
@@ -4,7 +4,7 @@ import pandas as pd
 import typing
 from buildstock_query.schema.query_params import TSQuery, BaseQuery, Query
 from buildstock_query import main
-from buildstock_query.schema.utilities import AnyColType, AnyTableType
+from buildstock_query.schema.utilities import AnyColType, AnyTableType, RestrictTuple
 from pydantic import Field
 from typing_extensions import deprecated
 
@@ -22,8 +22,8 @@ class BuildStockAggregate:
         upgrade_id: int | str = "0",
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = [],
         weights: Sequence[str | tuple] = [],
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
+        restrict: Sequence[RestrictTuple] = [],
+        avoid: Sequence[RestrictTuple] = [],
         get_quartiles: bool = False,
         get_nonzero_count: bool = False,
         agg_func: str | None = "sum",
@@ -40,8 +40,8 @@ class BuildStockAggregate:
         upgrade_id: int | str = "0",
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = [],
         weights: Sequence[str | tuple] = [],
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
+        restrict: Sequence[RestrictTuple] = [],
+        avoid: Sequence[RestrictTuple] = [],
         get_quartiles: bool = False,
         get_nonzero_count: bool = False,
         agg_func: str | None = "sum",
@@ -58,8 +58,8 @@ class BuildStockAggregate:
         upgrade_id: int | str = "0",
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = [],
         weights: Sequence[str | tuple] = [],
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
+        restrict: Sequence[RestrictTuple] = [],
+        avoid: Sequence[RestrictTuple] = [],
         get_quartiles: bool = False,
         get_nonzero_count: bool = False,
         agg_func: str | None = "sum",
@@ -122,8 +122,8 @@ class BuildStockAggregate:
         sort: bool = False,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = [],
         weights: Sequence[str | tuple] = [],
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
+        restrict: Sequence[RestrictTuple] = [],
+        avoid: Sequence[RestrictTuple] = [],
         split_enduses: bool = False,
         collapse_ts: bool = False,
         timestamp_grouping_func: str | None = None,
@@ -141,8 +141,8 @@ class BuildStockAggregate:
         sort: bool = False,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = [],
         weights: Sequence[str | tuple] = [],
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
+        restrict: Sequence[RestrictTuple] = [],
+        avoid: Sequence[RestrictTuple] = [],
         split_enduses: bool = False,
         collapse_ts: bool = False,
         timestamp_grouping_func: str | None = None,
@@ -162,8 +162,8 @@ class BuildStockAggregate:
         sort: bool = False,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = [],
         weights: Sequence[str | tuple] = [],
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = [],
+        restrict: Sequence[RestrictTuple] = [],
+        avoid: Sequence[RestrictTuple] = [],
         split_enduses: bool = False,
         collapse_ts: bool = False,
         timestamp_grouping_func: str | None = None,

--- a/buildstock_query/main.py
+++ b/buildstock_query/main.py
@@ -14,7 +14,7 @@ from typing_extensions import assert_never
 import typing
 from datetime import datetime
 from buildstock_query.schema.run_params import BSQParams
-from buildstock_query.schema.utilities import DBColType, SALabel, AnyColType, AnyTableType
+from buildstock_query.schema.utilities import DBColType, SALabel, SACol, AnyColType, AnyTableType, RestrictTuple
 from buildstock_query.schema.utilities import validate_arguments
 from buildstock_query.schema.utilities import MappedColumn
 from buildstock_query.schema.query_params import Query
@@ -746,11 +746,24 @@ class BuildStockQuery(QueryCore):
         bs_restrict = []  # restrict to apply to baseline table
         ts_restrict = []  # restrict to apply to timeseries table
         for col, restrict_vals in restrict:
-            if self.ts_table is not None and col in self.ts_table.columns:  # prioritize ts table
-                ts_restrict.append([self.ts_table.c[col], restrict_vals])
+            if self._restrict_targets_ts(col):  # prioritize ts table
+                col_name = col if isinstance(col, str) else col.name
+                ts_restrict.append([self.ts_table.c[col_name], restrict_vals])
             else:
                 bs_restrict.append([self._get_gcol(col, annual_only=True), restrict_vals])
         return bs_restrict, ts_restrict
+
+    def _restrict_targets_ts(self, col: AnyColType) -> bool:
+        if self.ts_table is None:
+            return False
+        if isinstance(col, str):
+            return col in self.ts_table.columns
+        if isinstance(col, SACol):
+            return getattr(col, "table", None) is self.ts_table
+        if isinstance(col, SALabel):
+            source_col = getattr(col, "element", None)
+            return isinstance(source_col, SACol) and getattr(source_col, "table", None) is self.ts_table
+        return False
 
     def _split_group_by(self, processed_group_by: list[DBColType]):
         # Some cols like "state" might be available in both ts and bs table
@@ -901,6 +914,42 @@ class BuildStockQuery(QueryCore):
     def _get_success_condition(self, table: AnyTableType):
         return self._get_completed_status_col(table) == self.db_schema.completion_values.success
 
+    def _get_applied_in_subquery(self, applied_in: Optional[Sequence[str | int]]):
+        """Return a building-id subquery for buildings where all listed upgrades applied successfully."""
+        if not applied_in:
+            return None
+        if self.up_table is None:
+            raise ValueError("No upgrades table found.")
+
+        upgrade_ids = list(dict.fromkeys(self._validate_upgrade(upgrade_id) for upgrade_id in applied_in))
+        bldg_id_col = self.up_table.c[self.building_id_column_name]
+        return (
+            sa.select(bldg_id_col)
+            .where(
+                self._up_upgrade_col.in_(upgrade_ids),
+                self._up_successful_condition,
+            )
+            .group_by(bldg_id_col)
+            .having(sa.func.count(sa.func.distinct(self._up_upgrade_col)) == len(upgrade_ids))
+        )
+
+    def _add_applied_in_restrict(
+        self,
+        restrict: Sequence[RestrictTuple],
+        *,
+        applied_in: Optional[Sequence[str | int]],
+        annual_only: bool,
+    ) -> list[RestrictTuple]:
+        """Append the applied-in building filter to the existing restrict list when requested."""
+        updated_restrict = list(restrict) if restrict else []
+        applied_subquery = self._get_applied_in_subquery(applied_in)
+        if applied_subquery is None:
+            return updated_restrict
+
+        bldg_col = self.bs_bldgid_column if annual_only or self.ts_table is None else self.ts_bldgid_column
+        updated_restrict.append((bldg_col, applied_subquery))
+        return updated_restrict
+
     @typing.overload
     def query(
         self,
@@ -916,9 +965,10 @@ class BuildStockQuery(QueryCore):
         sort: bool = True,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = Field(default_factory=list),
         weights: Sequence[str | tuple] = Field(default_factory=list),
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = Field(default_factory=list),
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = Field(default_factory=list),
+        restrict: Sequence[RestrictTuple] = Field(default_factory=list),
+        avoid: Sequence[RestrictTuple] = Field(default_factory=list),
         applied_only: bool = False,
+        applied_in: Sequence[str | int] | None = None,
         get_quartiles: bool = False,
         get_nonzero_count: bool = False,
         unload_to: str = "",
@@ -943,9 +993,10 @@ class BuildStockQuery(QueryCore):
         sort: bool = True,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = Field(default_factory=list),
         weights: Sequence[str | tuple] = Field(default_factory=list),
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = Field(default_factory=list),
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = Field(default_factory=list),
+        restrict: Sequence[RestrictTuple] = Field(default_factory=list),
+        avoid: Sequence[RestrictTuple] = Field(default_factory=list),
         applied_only: bool = False,
+        applied_in: Sequence[str | int] | None = None,
         get_quartiles: bool = False,
         get_nonzero_count: bool = False,
         unload_to: str = "",
@@ -970,9 +1021,10 @@ class BuildStockQuery(QueryCore):
         sort: bool = True,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = Field(default_factory=list),
         weights: Sequence[str | tuple] = Field(default_factory=list),
-        restrict: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = Field(default_factory=list),
-        avoid: Sequence[tuple[AnyColType, str | int | Sequence[int | str]]] = Field(default_factory=list),
+        restrict: Sequence[RestrictTuple] = Field(default_factory=list),
+        avoid: Sequence[RestrictTuple] = Field(default_factory=list),
         applied_only: bool = False,
+        applied_in: Sequence[str | int] | None = None,
         get_quartiles: bool = False,
         get_nonzero_count: bool = False,
         unload_to: str = "",
@@ -1000,12 +1052,16 @@ class BuildStockQuery(QueryCore):
                         where baseline_column_name and new_column_name are the columns on which the new_table
                         should be joined to baseline table.
             applied_only: Calculate savings shape based on only buildings to which the upgrade applied
+            applied_in: Optional list of upgrade ids. When set alongside `applied_only=True`, the query is further
+                        restricted to buildings for which all listed upgrades satisfy the run's success/applicability
+                        condition.
             weights: The additional columns to use as weight. The "build_existing_model.sample_weight" is already used.
                      It is specified as either list of string or list of tuples. When only string is used, the string
                      is the column name, when tuple is passed, the second element is the table name.
 
-            restrict: The list of where condition to restrict the results to. It should be specified as a list of tuple.
-                      Example: `[('state',['VA','AZ']), ("build_existing_model.lighting",['60% CFL']), ...]`
+            restrict: The list of where conditions to restrict the results to. Each entry can be a scalar equality,
+                      an `IN (...)` list, or a single-column SQLAlchemy subquery for `IN (subquery)`.
+                      Example: `[('state', ['VA', 'AZ']), (self.ts_bldgid_column, sa.select(...)), ...]`
 
             get_query_only: Skips submitting the query to Athena and just returns the query string. Useful for batch
                             submitting multiple queries or debugging

--- a/buildstock_query/main.py
+++ b/buildstock_query/main.py
@@ -765,6 +765,38 @@ class BuildStockQuery(QueryCore):
             return isinstance(source_col, SACol) and getattr(source_col, "table", None) is self.ts_table
         return False
 
+    def _is_timeseries_upgrade_restrict(self, col: AnyColType) -> bool:
+        if self.ts_table is None:
+            return False
+        if isinstance(col, str):
+            return col == "upgrade"
+
+        if getattr(col, "name", None) != "upgrade":
+            return False
+
+        if isinstance(col, SACol):
+            return getattr(col, "table", None) is self.ts_table
+
+        base_columns = getattr(col, "base_columns", None)
+        return bool(base_columns) and self.ts_table.c["upgrade"] in base_columns
+
+    def _validate_timeseries_upgrade_restrict(
+        self,
+        restrict: Sequence[RestrictTuple],
+        *,
+        annual_only: bool,
+        upgrade_id: str,
+    ) -> None:
+        if annual_only or upgrade_id == "0":
+            return
+
+        for col, _ in restrict:
+            if self._is_timeseries_upgrade_restrict(col):
+                raise ValueError(
+                    "Use `upgrade_id` instead of a `restrict` on the timeseries `upgrade` column "
+                    "for upgrade queries."
+                )
+
     def _split_group_by(self, processed_group_by: list[DBColType]):
         # Some cols like "state" might be available in both ts and bs table
         ts_group_by: list[DBColType] = []  # restrict to apply to baseline table

--- a/buildstock_query/query_core.py
+++ b/buildstock_query/query_core.py
@@ -289,42 +289,33 @@ class QueryCore:
             )
         return valid_tables[0].c[column_name]
 
+    def _get_subquery_table(
+        self, source_table: DBTableType, where_clause: sa.ColumnElement, alias_name: str
+    ) -> DBTableType:
+        raw_subquery = sa.select("*").select_from(source_table).where(where_clause)
+        return sa.text(self._compile(raw_subquery)).columns(*source_table.c).subquery(alias_name)
+
     def _get_tables(self, table_name: Union[str, tuple[str, Optional[str], Optional[str]]]):
         self._engine = self._create_athena_engine(
             region_name=self.region_name, database=self.db_name, workgroup=self.workgroup
         )
         if isinstance(table_name, str):
-            baseline_table = self._get_table(f"{table_name}{self.db_schema.table_suffix.baseline}")
-            ts_table = self._get_table(f"{table_name}{self.db_schema.table_suffix.timeseries}", missing_ok=True)
-            if self.db_schema.table_suffix.upgrades == self.db_schema.table_suffix.baseline:
-                upgrade_table = (
-                    sa.select(baseline_table)
-                    .where(sa.cast(baseline_table.c["upgrade"], sa.String) != "0")
-                    .alias("upgrade")
-                )
-                baseline_table = (
-                    sa.select(baseline_table)
-                    .where(sa.cast(baseline_table.c["upgrade"], sa.String) == "0")
-                    .alias("baseline")
-                )
-            else:
-                upgrade_table = self._get_table(f"{table_name}{self.db_schema.table_suffix.upgrades}", missing_ok=True)
+            baseline_table_name = f"{table_name}{self.db_schema.table_suffix.baseline}"
+            ts_table_name = f"{table_name}{self.db_schema.table_suffix.timeseries}"
+            upgrade_table_name = f"{table_name}{self.db_schema.table_suffix.upgrades}"
         else:
-            baseline_table = self._get_table(f"{table_name[0]}")
-            ts_table = self._get_table(f"{table_name[1]}", missing_ok=True) if table_name[1] else None
-            if table_name[2] == table_name[0]:
-                upgrade_table = (
-                    sa.select(baseline_table)
-                    .where(sa.cast(baseline_table.c["upgrade"], sa.String) != "0")
-                    .alias("upgrade")
-                )
-                baseline_table = (
-                    sa.select(baseline_table)
-                    .where(sa.cast(baseline_table.c["upgrade"], sa.String) == "0")
-                    .alias("baseline")
-                )
-            else:
-                upgrade_table = self._get_table(f"{table_name[2]}", missing_ok=True) if table_name[2] else None
+            baseline_table_name = table_name[0]
+            ts_table_name = table_name[1]
+            upgrade_table_name = table_name[2]
+
+        baseline_table = self._get_table(baseline_table_name)
+        ts_table = self._get_table(ts_table_name, missing_ok=True) if ts_table_name else None
+        if baseline_table_name == upgrade_table_name:
+            upgrade_col = sa.cast(baseline_table.c["upgrade"], sa.String)
+            upgrade_table = self._get_subquery_table(baseline_table, upgrade_col != "0", "upgrade")
+            baseline_table = self._get_subquery_table(baseline_table, upgrade_col == "0", "baseline")
+        else:
+            upgrade_table = self._get_table(upgrade_table_name, missing_ok=True) if upgrade_table_name else None
         return baseline_table, ts_table, upgrade_table
 
     def _initialize_book_keeping(self, execution_history):

--- a/buildstock_query/query_core.py
+++ b/buildstock_query/query_core.py
@@ -40,6 +40,7 @@ from buildstock_query.schema.utilities import (
 import hashlib
 import toml
 import uuid
+from sqlalchemy.sql.selectable import SelectBase, Subquery
 
 urllib3.disable_warnings()
 
@@ -1126,11 +1127,28 @@ class QueryCore:
             label += f"__{agg_func}"
         return label
 
+    @staticmethod
+    def _normalize_restrict_subquery(criteria):
+        if isinstance(criteria, SelectBase):
+            if len(criteria.selected_columns) != 1:
+                raise ValueError("Subquery restrictions must select exactly one column.")
+            return criteria
+
+        if isinstance(criteria, Subquery):
+            if len(criteria.c) != 1:
+                raise ValueError("Subquery restrictions must select exactly one column.")
+            return sa.select(next(iter(criteria.c)))
+
+        return None
+
     def _get_restrict_clauses(self, restrict, annual_only=False):
         clauses = []
         for col_str, criteria in restrict:
             col = self._get_column(col_str, annual_only=annual_only)
-            if isinstance(criteria, (list, tuple)):
+            subquery = self._normalize_restrict_subquery(criteria)
+            if subquery is not None:
+                clauses.append(col.in_(subquery))
+            elif isinstance(criteria, Sequence) and not isinstance(criteria, str):
                 if len(criteria) > 1:
                     clauses.append(col.in_(criteria))
                 elif len(criteria) == 1:
@@ -1154,7 +1172,10 @@ class QueryCore:
         where_clauses = []
         for col_str, criteria in avoid:
             col = self._get_column(col_str, annual_only=annual_only)
-            if isinstance(criteria, (list, tuple)):
+            subquery = self._normalize_restrict_subquery(criteria)
+            if subquery is not None:
+                where_clauses.append(col.not_in(subquery))
+            elif isinstance(criteria, Sequence) and not isinstance(criteria, str):
                 if len(criteria) > 1:
                     where_clauses.append(col.not_in(criteria))
                 elif len(criteria) == 1:

--- a/buildstock_query/savings_query.py
+++ b/buildstock_query/savings_query.py
@@ -104,6 +104,11 @@ class BuildStockSavings:
             raise ValueError("Only 'sum' is supported for savings_shape")
 
         upgrade_id = self._bsq._validate_upgrade(params.upgrade_id)
+        self._bsq._validate_timeseries_upgrade_restrict(
+            params.restrict,
+            annual_only=params.annual_only,
+            upgrade_id=upgrade_id,
+        )
         if params.timestamp_grouping_func and params.timestamp_grouping_func not in ["hour", "day", "month"]:
             raise ValueError("timestamp_grouping_func must be one of ['hour', 'day', 'month']")
 

--- a/buildstock_query/savings_query.py
+++ b/buildstock_query/savings_query.py
@@ -7,7 +7,7 @@ from sqlalchemy import func as safunc
 import sqlalchemy as sa
 from typing import Union
 from collections.abc import Sequence
-from buildstock_query.schema.utilities import AnyColType
+from buildstock_query.schema.utilities import AnyColType, RestrictTuple
 from pydantic import Field
 from typing_extensions import deprecated
 
@@ -32,7 +32,7 @@ class BuildStockSavings:
         enduses: Sequence[AnyColType],
         upgrade_id: str,
         applied_only: bool,
-        restrict: Sequence[tuple[AnyColType, Union[str, int, Sequence[Union[int, str]]]]] = Field(default_factory=list),
+        restrict: Sequence[RestrictTuple] = Field(default_factory=list),
         ts_group_by: Sequence[Union[AnyColType, tuple[str, str]]] = Field(default_factory=list),
     ):
         if self._bsq.ts_table is None:
@@ -107,6 +107,11 @@ class BuildStockSavings:
         if params.timestamp_grouping_func and params.timestamp_grouping_func not in ["hour", "day", "month"]:
             raise ValueError("timestamp_grouping_func must be one of ['hour', 'day', 'month']")
 
+        bs_restrict = self._bsq._add_applied_in_restrict(
+            params.restrict,
+            applied_in=params.applied_in,
+            annual_only=params.annual_only,
+        )
         enduse_cols = self._bsq._get_enduse_cols(
             params.enduses, table="baseline" if params.annual_only else "timeseries"
         )
@@ -117,7 +122,7 @@ class BuildStockSavings:
         if params.annual_only:
             ts_b, ts_u, tbljoin = self.__get_annual_bs_up_table(upgrade_id, params.applied_only)
         else:
-            params.restrict, ts_restrict = self._bsq._split_restrict(params.restrict)
+            bs_restrict, ts_restrict = self._bsq._split_restrict(bs_restrict)
             bs_group_by, ts_group_by = self._bsq._split_group_by(group_by_selection)
             ts_b, ts_u, tbljoin = self.__get_timeseries_bs_up_table(
                 enduse_cols, upgrade_id, params.applied_only, ts_restrict, ts_group_by
@@ -203,7 +208,7 @@ class BuildStockSavings:
         query_cols = grouping_metrics_selection + query_cols
         query = sa.select(*query_cols).select_from(tbljoin)
         query = self._bsq._add_join(query, params.join_list)
-        query = self._bsq._add_restrict(query, params.restrict)
+        query = self._bsq._add_restrict(query, bs_restrict)
         if params.annual_only:
             query = query.where(self._bsq._bs_successful_condition)
         query = self._bsq._add_group_by(query, group_by_selection)

--- a/buildstock_query/savings_query.pyi
+++ b/buildstock_query/savings_query.pyi
@@ -1,7 +1,7 @@
 import pandas as pd
 from typing import Sequence, Union
 from buildstock_query.schema.query_params import SavingsQuery
-from buildstock_query.schema.utilities import AnyColType, AnyTableType
+from buildstock_query.schema.utilities import AnyColType, AnyTableType, RestrictTuple
 import buildstock_query.main as main
 from typing import Optional
 from pydantic import Field
@@ -24,9 +24,7 @@ class BuildStockSavings:
                                      enduses: Sequence[AnyColType],
                                      upgrade_id: Union[int, str],
                                      applied_only: bool,
-                                     restrict:
-                                     Sequence[tuple[AnyColType, Union[str, int, Sequence[Union[int, str]]]]
-                                              ] = Field(default_factory=list),
+                                     restrict: Sequence[RestrictTuple] = Field(default_factory=list),
                                      ts_group_by: Sequence[Union[AnyColType, tuple[str, str]]
                                                            ] = Field(default_factory=list)):
         ...
@@ -46,9 +44,9 @@ class BuildStockSavings:
         sort: bool = True,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = Field(default_factory=list),
         weights: Sequence[Union[str, tuple]] = Field(default_factory=list),
-        restrict: Sequence[tuple[AnyColType, Union[str, int, Sequence[Union[int, str]]]]
-                           ] = Field(default_factory=list),
+        restrict: Sequence[RestrictTuple] = Field(default_factory=list),
         applied_only: bool = False,
+        applied_in: Optional[Sequence[Union[str, int]]] = None,
         get_quartiles: bool = False,
         unload_to: str = '',
         partition_by: Optional[Sequence[str]] = None,
@@ -69,9 +67,9 @@ class BuildStockSavings:
         sort: bool = True,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = Field(default_factory=list),
         weights: Sequence[Union[str, tuple]] = Field(default_factory=list),
-        restrict: Sequence[tuple[AnyColType, Union[str, int, Sequence[Union[int, str]]]]
-                           ] = Field(default_factory=list),
+        restrict: Sequence[RestrictTuple] = Field(default_factory=list),
         applied_only: bool = False,
+        applied_in: Optional[Sequence[Union[str, int]]] = None,
         get_quartiles: bool = False,
         unload_to: str = '',
         partition_by: Optional[Sequence[str]] = None,
@@ -92,9 +90,9 @@ class BuildStockSavings:
         sort: bool = True,
         join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = Field(default_factory=list),
         weights: Sequence[Union[str, tuple]] = Field(default_factory=list),
-        restrict: Sequence[tuple[AnyColType, Union[str, int, Sequence[Union[int, str]]]]
-                           ] = Field(default_factory=list),
+        restrict: Sequence[RestrictTuple] = Field(default_factory=list),
         applied_only: bool = False,
+        applied_in: Optional[Sequence[Union[str, int]]] = None,
         get_quartiles: bool = False,
         unload_to: str = '',
         partition_by: Optional[Sequence[str]] = None,
@@ -115,6 +113,9 @@ class BuildStockSavings:
                         where baseline_column_name and new_column_name are the columns on which the new_table
                         should be joined to baseline table.
             applied_only: Calculate savings shape based on only buildings to which the upgrade applied
+            applied_in: Optional list of upgrade ids. When set alongside `applied_only=True`, the query is further
+                        restricted to buildings for which all listed upgrades satisfy the run's success/applicability
+                        condition.
             weights: The additional columns to use as weight. The "build_existing_model.sample_weight" is already used.
                      It is specified as either list of string or list of tuples. When only string is used, the string
                      is the column name, when tuple is passed, the second element is the table name.

--- a/buildstock_query/schema/query_params.py
+++ b/buildstock_query/schema/query_params.py
@@ -2,9 +2,16 @@ from pydantic import ConfigDict, BaseModel, Field
 from typing import Optional, Union
 from collections.abc import Sequence
 from typing import Literal
-from buildstock_query.schema.utilities import AnyTableType, AnyColType
+from buildstock_query.schema.utilities import AnyTableType, AnyColType, RestrictTuple
 from pydantic import model_validator
 from typing_extensions import Self
+
+
+def _normalize_applied_in(applied_in: Optional[Sequence[Union[str, int]]]) -> Optional[list[str]]:
+    if applied_in is None:
+        return None
+    normalized = list(dict.fromkeys(str(upgrade) for upgrade in applied_in))
+    return normalized or None
 
 
 class BaseQuery(BaseModel):
@@ -13,8 +20,8 @@ class BaseQuery(BaseModel):
     upgrade_id: str = "0"
     sort: bool = True
     join_list: Sequence[tuple[AnyTableType, AnyColType, AnyColType]] = Field(default_factory=list)
-    restrict: Sequence[tuple[AnyColType, Union[str, int, Sequence[Union[int, str]]]]] = Field(default_factory=list)
-    avoid: Sequence[tuple[AnyColType, Union[str, int, Sequence[Union[int, str]]]]] = Field(default_factory=list)
+    restrict: Sequence[RestrictTuple] = Field(default_factory=list)
+    avoid: Sequence[RestrictTuple] = Field(default_factory=list)
     weights: Sequence[Union[str, tuple, AnyColType]] = Field(default_factory=list)
     get_quartiles: bool = False
     get_nonzero_count: bool = False
@@ -33,8 +40,18 @@ class TSQuery(BaseQuery):
 class SavingsQuery(TSQuery):
     annual_only: bool = True
     applied_only: bool = False
+    applied_in: Optional[Sequence[Union[str, int]]] = None
     unload_to: str = ""
     partition_by: Sequence[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> Self:
+        self.applied_in = _normalize_applied_in(self.applied_in)
+        if self.applied_in and not self.applied_only:
+            raise ValueError("applied_in cannot be set when applied_only is False")
+        if self.applied_only and self.upgrade_id == "0":
+            raise ValueError("applied_only cannot be set when upgrade_id is '0'")
+        return self
 
 
 class UtilityTSQuery(TSQuery):
@@ -50,20 +67,25 @@ class Query(BaseQuery):
     timestamp_grouping_func: Optional[Literal["year", "month", "day", "hour"]] = None
     partition_by: Sequence[str] = Field(default_factory=list)
     applied_only: Optional[bool] = Field(default=None)
+    applied_in: Optional[Sequence[Union[str, int]]] = None
     unload_to: Optional[str] = None
 
     @model_validator(mode="after")
     def validate_consistency(self) -> Self:
+        self.applied_in = _normalize_applied_in(self.applied_in)
+        effective_applied_only = self.upgrade_id != "0" if self.applied_only is None else self.applied_only
         if self.include_savings and self.upgrade_id == "0":
             raise ValueError("include_savings cannot be True when upgrade_id is '0'")
         if self.include_baseline and self.upgrade_id == "0":
             raise ValueError("include_baseline cannot be set when upgrade_id is '0'")
         if self.timestamp_grouping_func and self.annual_only:
             raise ValueError("annual_only must be False when timestamp_grouping_func is provided")
-        if self.applied_only and self.upgrade_id == "0":
+        if effective_applied_only and self.upgrade_id == "0":
             raise ValueError("applied_only cannot be set when upgrade_id is '0'")
+        if self.applied_in and not effective_applied_only:
+            raise ValueError("applied_in cannot be set when applied_only is False")
         if self.get_nonzero_count and not self.annual_only:
             raise ValueError("get_nonzero_count cannot be True when annual_only is False")
         if self.applied_only is None:
-            self.applied_only = self.upgrade_id != "0"  # False for baseline, True otherwise
+            self.applied_only = effective_applied_only  # False for baseline, True otherwise
         return self

--- a/buildstock_query/schema/utilities.py
+++ b/buildstock_query/schema/utilities.py
@@ -24,7 +24,7 @@ class MappedColumn(BaseModel):
 
 
 AnyColType = DBColType | str | MappedColumn
-RestrictValue = str | int | Sequence[int | str] | SelectBase | Subquery
+RestrictValue = str | int | bool | Sequence[int | str | bool] | SelectBase | Subquery
 RestrictTuple = tuple[AnyColType, RestrictValue]
 
 validate_arguments = validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/buildstock_query/schema/utilities.py
+++ b/buildstock_query/schema/utilities.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from pydantic import ConfigDict, BaseModel, validate_call
 import sqlalchemy as sa
 from sqlalchemy.sql.elements import Label, ColumnElement
-from sqlalchemy.sql.selectable import Subquery
+from sqlalchemy.sql.selectable import SelectBase, Subquery
 # from buildstock_query import BuildStockQuery  # can't import due to circular import
 
 
@@ -24,5 +24,7 @@ class MappedColumn(BaseModel):
 
 
 AnyColType = DBColType | str | MappedColumn
+RestrictValue = str | int | Sequence[int | str] | SelectBase | Subquery
+RestrictTuple = tuple[AnyColType, RestrictValue]
 
 validate_arguments = validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="buildstock_query",
-    version="v0.2.0",
+    version="0.3.0",
     description="Python library for querying and analyzing ResStock and ComStock",
     author="Rajendra Adhikari",
     packages=find_packages(),

--- a/tests/test_BuildStockQuery.py
+++ b/tests/test_BuildStockQuery.py
@@ -8,7 +8,7 @@ import pytest
 import sqlalchemy as sa
 
 from buildstock_query.main import BuildStockQuery
-from buildstock_query.schema.query_params import Query, BaseQuery
+from buildstock_query.schema.query_params import Query, BaseQuery, SavingsQuery
 
 
 @pytest.fixture(scope="module")
@@ -201,6 +201,207 @@ class TestBuildStockQuery:
         )
 
         assert f"{bsq.ts_table.name}.{bsq.building_id_column_name} = 1" in query
+
+    def test_timeseries_query_supports_subquery_restrict_with_ts_column(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        table_name = "small_run_baseline_20230810_100"
+
+        metadata = sa.MetaData()
+        baseline = sa.Table(
+            f"{table_name}_baseline",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("completed_status", sa.String),
+        )
+        timeseries = sa.Table(
+            f"{table_name}_timeseries",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("time", sa.DateTime),
+            sa.Column("upgrade", sa.String),
+            sa.Column("fuel_use__electricity__total__kwh", sa.Float),
+        )
+        upgrades = sa.Table(
+            f"{table_name}_upgrades",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("upgrade", sa.String),
+            sa.Column("state", sa.String),
+            sa.Column("applicability", sa.Boolean),
+        )
+
+        def _get_local_tables(self, requested_table_name):
+            assert requested_table_name == table_name
+            return baseline, timeseries, upgrades
+
+        monkeypatch.setattr(BuildStockQuery, "_get_tables", _get_local_tables)
+        bsq = BuildStockQuery(
+            db_name="resstock_core",
+            table_name=table_name,
+            workgroup="rescore",
+            buildstock_type="resstock",
+            skip_reports=True,
+            sample_weight_override=1,
+        )
+        monkeypatch.setattr(bsq, "get_available_upgrades", lambda: ["0", "1", "2", "3", "4"])
+
+        eligible_buildings = (
+            sa.select(upgrades.c.building_id)
+            .where(
+                upgrades.c.state == "CO",
+                upgrades.c.upgrade.in_(["1", "2", "3", "4"]),
+                upgrades.c.applicability.is_(True),
+            )
+            .group_by(upgrades.c.building_id)
+            .having(sa.func.count() == 4)
+        )
+
+        query = bsq.query(
+            annual_only=False,
+            upgrade_id="1",
+            enduses=["fuel_use__electricity__total__kwh"],
+            restrict=[(bsq.ts_bldgid_column, eligible_buildings)],
+            get_query_only=True,
+        )
+
+        assert "IN (SELECT" in query
+        assert "HAVING count(*) = 4" in query
+        assert "applicability IS true" in query
+
+    def test_query_model_rejects_applied_in_without_applied_only(self) -> None:
+        with pytest.raises(ValueError, match="applied_in cannot be set when applied_only is False"):
+            Query.model_validate(
+                {
+                    "upgrade_id": "1",
+                    "enduses": ["fuel_use__electricity__total__kwh"],
+                    "applied_only": False,
+                    "applied_in": ["1", "2"],
+                }
+            )
+
+        with pytest.raises(ValueError, match="applied_in cannot be set when applied_only is False"):
+            SavingsQuery.model_validate(
+                {
+                    "upgrade_id": "1",
+                    "enduses": ["fuel_use__electricity__total__kwh"],
+                    "applied_only": False,
+                    "applied_in": ["1", "2"],
+                }
+            )
+
+    def test_timeseries_query_applied_in_adds_subquery_restrict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        table_name = "small_run_baseline_20230810_100"
+
+        metadata = sa.MetaData()
+        baseline = sa.Table(
+            f"{table_name}_baseline",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("completed_status", sa.String),
+        )
+        timeseries = sa.Table(
+            f"{table_name}_timeseries",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("time", sa.DateTime),
+            sa.Column("upgrade", sa.String),
+            sa.Column("fuel_use__electricity__total__kwh", sa.Float),
+        )
+        upgrades = sa.Table(
+            f"{table_name}_upgrades",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("upgrade", sa.String),
+            sa.Column("completed_status", sa.String),
+        )
+
+        def _get_local_tables(self, requested_table_name):
+            assert requested_table_name == table_name
+            return baseline, timeseries, upgrades
+
+        monkeypatch.setattr(BuildStockQuery, "_get_tables", _get_local_tables)
+        bsq = BuildStockQuery(
+            db_name="resstock_core",
+            table_name=table_name,
+            workgroup="rescore",
+            buildstock_type="resstock",
+            skip_reports=True,
+            sample_weight_override=1,
+        )
+        monkeypatch.setattr(bsq, "get_available_upgrades", lambda: ["0", "1", "2", "3", "4"])
+
+        query = bsq.query(
+            annual_only=False,
+            upgrade_id="1",
+            enduses=["fuel_use__electricity__total__kwh"],
+            applied_in=["1", "2", "3", "4"],
+            get_query_only=True,
+        )
+
+        assert "IN (SELECT" in query
+        assert "HAVING count(distinct" in query
+        assert "IN ('1', '2', '3', '4')" in query
+        assert "completed_status = 'Success'" in query
+
+    def test_savings_shape_applied_in_adds_subquery_restrict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        table_name = "small_run_baseline_20230810_100"
+
+        metadata = sa.MetaData()
+        baseline = sa.Table(
+            f"{table_name}_baseline",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("completed_status", sa.String),
+        )
+        timeseries = sa.Table(
+            f"{table_name}_timeseries",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("time", sa.DateTime),
+            sa.Column("upgrade", sa.String),
+            sa.Column("fuel_use__electricity__total__kwh", sa.Float),
+        )
+        upgrades = sa.Table(
+            f"{table_name}_upgrades",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("upgrade", sa.String),
+            sa.Column("completed_status", sa.String),
+        )
+
+        def _get_local_tables(self, requested_table_name):
+            assert requested_table_name == table_name
+            return baseline, timeseries, upgrades
+
+        monkeypatch.setattr(BuildStockQuery, "_get_tables", _get_local_tables)
+        bsq = BuildStockQuery(
+            db_name="resstock_core",
+            table_name=table_name,
+            workgroup="rescore",
+            buildstock_type="resstock",
+            skip_reports=True,
+            sample_weight_override=1,
+        )
+        monkeypatch.setattr(bsq, "get_available_upgrades", lambda: ["0", "1", "2", "3", "4"])
+
+        query = bsq.savings.savings_shape(
+            annual_only=False,
+            upgrade_id="1",
+            enduses=["fuel_use__electricity__total__kwh"],
+            applied_only=True,
+            applied_in=["1", "2", "3", "4"],
+            get_query_only=True,
+        )
+
+        assert "IN (SELECT" in query
+        assert "HAVING count(distinct" in query
+        assert "IN ('1', '2', '3', '4')" in query
+        assert "completed_status = 'Success'" in query
 
     def test_timeseries_matches_query(self, bsq: BuildStockQuery) -> None:
         agg_df = bsq.agg.aggregate_timeseries(

--- a/tests/test_BuildStockQuery.py
+++ b/tests/test_BuildStockQuery.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import sqlalchemy as sa
 import toml
+from pyathena.error import OperationalError
 
 from buildstock_query.main import BuildStockQuery
 from buildstock_query.db_schema.db_schema_model import DBSchema
@@ -17,13 +18,16 @@ from buildstock_query.schema.query_params import Query, BaseQuery, SavingsQuery
 @pytest.fixture(scope="module")
 def bsq() -> Generator[BuildStockQuery, None, None]:
     """Shared BuildStockQuery instance backed by the sdr_magic17 run."""
-    obj = BuildStockQuery(
-        db_name="resstock_core",
-        table_name="sdr_magic17",
-        workgroup="rescore",
-        buildstock_type="resstock",
-        skip_reports=True,
-    )
+    try:
+        obj = BuildStockQuery(
+            db_name="resstock_core",
+            table_name="sdr_magic17",
+            workgroup="rescore",
+            buildstock_type="resstock",
+            skip_reports=True,
+        )
+    except OperationalError as exc:
+        pytest.skip(f"Athena integration tests unavailable: {exc}")
     # Warm cache once so subsequent calls can reuse local artifacts where possible.
     obj.save_cache()
     yield obj
@@ -338,6 +342,74 @@ class TestBuildStockQuery:
                     "applied_in": ["1", "2"],
                 }
             )
+
+    @pytest.mark.parametrize(
+        "query_runner",
+        [
+            lambda bsq, restrict: bsq.query(
+                annual_only=False,
+                upgrade_id="1",
+                enduses=["fuel_use__electricity__total__kwh"],
+                restrict=restrict,
+                get_query_only=True,
+            ),
+            lambda bsq, restrict: bsq.savings.savings_shape(
+                annual_only=False,
+                upgrade_id="1",
+                enduses=["fuel_use__electricity__total__kwh"],
+                restrict=restrict,
+                get_query_only=True,
+            ),
+        ],
+    )
+    def test_timeseries_upgrade_restrict_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, query_runner
+    ) -> None:
+        table_name = "small_run_baseline_20230810_100"
+
+        metadata = sa.MetaData()
+        baseline = sa.Table(
+            f"{table_name}_baseline",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("completed_status", sa.String),
+        )
+        timeseries = sa.Table(
+            f"{table_name}_timeseries",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("time", sa.DateTime),
+            sa.Column("upgrade", sa.Integer),
+            sa.Column("fuel_use__electricity__total__kwh", sa.Float),
+        )
+        upgrades = sa.Table(
+            f"{table_name}_upgrades",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("upgrade", sa.String),
+            sa.Column("completed_status", sa.String),
+        )
+
+        def _get_local_tables(self, requested_table_name):
+            assert requested_table_name == table_name
+            return baseline, timeseries, upgrades
+
+        monkeypatch.setattr(BuildStockQuery, "_get_tables", _get_local_tables)
+        bsq = BuildStockQuery(
+            db_name="resstock_core",
+            table_name=table_name,
+            workgroup="rescore",
+            buildstock_type="resstock",
+            skip_reports=True,
+            sample_weight_override=1,
+        )
+        monkeypatch.setattr(bsq, "get_available_upgrades", lambda: ["0", "1"])
+
+        with pytest.raises(
+            ValueError,
+            match="Use `upgrade_id` instead of a `restrict` on the timeseries `upgrade` column",
+        ):
+            query_runner(bsq, [("upgrade", [1])])
 
     def test_timeseries_query_applied_in_adds_subquery_restrict(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_BuildStockQuery.py
+++ b/tests/test_BuildStockQuery.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import ast
+import pathlib
 from typing import Generator
 
 import pandas as pd
 import pytest
 import sqlalchemy as sa
+import toml
 
 from buildstock_query.main import BuildStockQuery
+from buildstock_query.db_schema.db_schema_model import DBSchema
 from buildstock_query.schema.query_params import Query, BaseQuery, SavingsQuery
 
 
@@ -201,6 +204,52 @@ class TestBuildStockQuery:
         )
 
         assert f"{bsq.ts_table.name}.{bsq.building_id_column_name} = 1" in query
+
+    @pytest.mark.parametrize("table_name", ["shared_run", ("shared_run_baseline", None, "shared_run_baseline")])
+    def test_get_tables_keeps_exported_columns_for_shared_baseline_table(
+        self, table_name: str | tuple[str, None, str]
+    ) -> None:
+        schema_path = pathlib.Path(__file__).resolve().parents[1] / "buildstock_query" / "db_schema" / "resstock_default.toml"
+        db_schema_dict = toml.load(schema_path)
+        db_schema_dict["table_suffix"]["upgrades"] = db_schema_dict["table_suffix"]["baseline"]
+
+        bsq = BuildStockQuery.__new__(BuildStockQuery)
+        bsq.region_name = "us-west-2"
+        bsq.db_name = "resstock_core"
+        bsq.workgroup = "rescore"
+        bsq.db_schema = DBSchema.model_validate(db_schema_dict)
+
+        metadata = sa.MetaData()
+        source_table = sa.Table(
+            "shared_run_baseline",
+            metadata,
+            sa.Column("building_id", sa.Integer),
+            sa.Column("upgrade", sa.String),
+            sa.Column("completed_status", sa.String),
+        )
+        tables = {source_table.name: source_table}
+
+        bsq._create_athena_engine = lambda **kwargs: object()
+
+        def _get_local_table(requested_table_name, missing_ok=False):
+            if requested_table_name in tables:
+                return tables[requested_table_name]
+            if missing_ok:
+                return None
+            raise sa.exc.NoSuchTableError(requested_table_name)
+
+        bsq._get_table = _get_local_table
+
+        baseline_table, ts_table, upgrade_table = bsq._get_tables(table_name)
+
+        assert ts_table is None
+        assert baseline_table.c["building_id"].name == "building_id"
+        assert upgrade_table.c["building_id"].name == "building_id"
+
+        compiled_baseline = " ".join(bsq._compile(sa.select(baseline_table.c["building_id"])).split())
+        compiled_upgrade = " ".join(bsq._compile(sa.select(upgrade_table.c["building_id"])).split())
+        assert f"SELECT * FROM {source_table.name}" in compiled_baseline
+        assert f"SELECT * FROM {source_table.name}" in compiled_upgrade
 
     def test_timeseries_query_supports_subquery_restrict_with_ts_column(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_BuildStockSavings.py
+++ b/tests/test_BuildStockSavings.py
@@ -2,6 +2,7 @@ import numpy as np
 from unittest.mock import MagicMock
 from buildstock_query.main import BuildStockQuery, SimInfo
 import pytest
+from pyathena.error import OperationalError
 from tests.utils import assert_query_equal, load_tbl_from_pkl, load_cache_from_pkl
 from buildstock_query.helpers import KWH2MBTU
 import re
@@ -22,12 +23,15 @@ def temp_history_file():
 def my_athena() -> Generator[BuildStockQuery, None, None]:  # pylint: disable=invalid-name
     """Shared BuildStockQuery instance for all tests."""
     """Shared BuildStockQuery instance for all tests."""
-    obj = BuildStockQuery(
-        db_name="resstock_core",
-        table_name="sdr_magic17",
-        workgroup="rescore",
-        buildstock_type="resstock",
-    )
+    try:
+        obj = BuildStockQuery(
+            db_name="resstock_core",
+            table_name="sdr_magic17",
+            workgroup="rescore",
+            buildstock_type="resstock",
+        )
+    except OperationalError as exc:
+        pytest.skip(f"Athena integration tests unavailable: {exc}")
     # Warm-up – ensures that subsequent queries can leverage the local cache when available
     obj.save_cache()
     yield obj

--- a/tests/test_BuildStockUtility.py
+++ b/tests/test_BuildStockUtility.py
@@ -5,6 +5,7 @@ from typing import Generator
 import numpy as np
 import pandas as pd
 import pytest
+from pyathena.error import OperationalError
 
 from buildstock_query.main import BuildStockQuery
 
@@ -12,13 +13,16 @@ from buildstock_query.main import BuildStockQuery
 @pytest.fixture(scope="module")
 def bsq() -> Generator[BuildStockQuery, None, None]:
     """Shared BuildStockQuery instance backed by the sdr_magic17 run."""
-    obj = BuildStockQuery(
-        db_name="resstock_core",
-        table_name="sdr_magic17",
-        workgroup="rescore",
-        buildstock_type="resstock",
-        skip_reports=True,
-    )
+    try:
+        obj = BuildStockQuery(
+            db_name="resstock_core",
+            table_name="sdr_magic17",
+            workgroup="rescore",
+            buildstock_type="resstock",
+            skip_reports=True,
+        )
+    except OperationalError as exc:
+        pytest.skip(f"Athena integration tests unavailable: {exc}")
     obj.save_cache()
     yield obj
     obj.save_cache()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from typing import Generator
+from pyathena.error import OperationalError
 from buildstock_query import BuildStockQuery
 from buildstock_query.schema.utilities import MappedColumn
 
@@ -11,12 +12,15 @@ from buildstock_query.schema.utilities import MappedColumn
 def bsq() -> Generator[BuildStockQuery, None, None]:  # pylint: disable=invalid-name
     """Shared BuildStockQuery instance for all tests."""
     """Shared BuildStockQuery instance for all tests."""
-    obj = BuildStockQuery(
-        db_name="resstock_core",
-        table_name="sdr_magic17",
-        workgroup="rescore",
-        buildstock_type="resstock",
-    )
+    try:
+        obj = BuildStockQuery(
+            db_name="resstock_core",
+            table_name="sdr_magic17",
+            workgroup="rescore",
+            buildstock_type="resstock",
+        )
+    except OperationalError as exc:
+        pytest.skip(f"Athena integration tests unavailable: {exc}")
     # Warm-up – ensures that subsequent queries can leverage the local cache when available
     obj.save_cache()
     yield obj

--- a/tests/test_query_core_cache_paths.py
+++ b/tests/test_query_core_cache_paths.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import datetime
+import logging
+from unittest.mock import MagicMock
+
+from buildstock_query.query_core import QueryCore
+
+
+def _make_query_core(pages: list[dict]) -> tuple[QueryCore, MagicMock]:
+    qc = QueryCore.__new__(QueryCore)
+    paginator = MagicMock()
+    paginator.paginate.return_value = pages
+    qc._aws_s3 = MagicMock()
+    qc._aws_s3.get_paginator.return_value = paginator
+    return qc, paginator
+
+
+class TestQueryCoreCachePaths:
+    def test_get_query_result_location_selects_newest_leaf_folder(self, caplog) -> None:
+        base = "bsq_athena_unload_results/abc123/"
+        pages = [{
+            "Contents": [
+                {
+                    "Key": f"{base}older/part-0.parquet",
+                    "LastModified": datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+                },
+                {
+                    "Key": f"{base}newer/part-0.parquet",
+                    "LastModified": datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc),
+                },
+                {
+                    "Key": f"{base}newer/part-1.parquet",
+                    "LastModified": datetime.datetime(2024, 1, 3, tzinfo=datetime.timezone.utc),
+                },
+            ]
+        }]
+        qc, paginator = _make_query_core(pages)
+
+        with caplog.at_level(logging.WARNING):
+            result = qc._get_query_result_location("s3://test-bucket/bsq_athena_unload_results/abc123")
+
+        assert result == "s3://test-bucket/bsq_athena_unload_results/abc123/newer/"
+        paginator.paginate.assert_called_once_with(
+            Bucket="test-bucket",
+            Prefix="bsq_athena_unload_results/abc123/",
+        )
+        assert "Multiple cached UNLOAD result folders found" in caplog.text
+
+    def test_get_query_result_location_returns_none_without_child_folders(self) -> None:
+        pages = [{
+            "Contents": [
+                {
+                    "Key": "bsq_athena_unload_results/abc123/_SUCCESS",
+                    "LastModified": datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+                },
+                {
+                    "Key": "bsq_athena_unload_results/abc123/",
+                    "LastModified": datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+                },
+            ]
+        }]
+        qc, _ = _make_query_core(pages)
+
+        result = qc._get_query_result_location("s3://test-bucket/bsq_athena_unload_results/abc123/")
+
+        assert result is None
+
+    def test_get_query_result_location_ignores_root_level_keys(self) -> None:
+        base = "bsq_athena_unload_results/abc123/"
+        pages = [{
+            "Contents": [
+                {
+                    "Key": f"{base}_SUCCESS",
+                    "LastModified": datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+                },
+                {
+                    "Key": f"{base}leaf/part-0.parquet",
+                    "LastModified": datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc),
+                },
+            ]
+        }]
+        qc, _ = _make_query_core(pages)
+
+        result = qc._get_query_result_location("s3://test-bucket/bsq_athena_unload_results/abc123")
+
+        assert result == "s3://test-bucket/bsq_athena_unload_results/abc123/leaf/"


### PR DESCRIPTION
## Summary
- Add applied_in support for query and savings paths so buildings can be filtered to those where all requested upgrades apply.
- Substantially reduce the query volume by using "select * from comibined_table where upgrade=0 as baseline" style. 
- Reject ambiguous timeseries restrict=[('upgrade', ...)] usage on upgrade queries with a clear error.
## Validation
- .venv/bin/python -m pytest -x tests/test_query_core_cache_paths.py
- .venv/bin/python -m pytest -x tests/test_query.py (54 passed live with Athena)
- .venv/bin/python -m pytest -x tests/test_BuildStockQuery.py tests/test_BuildStockSavings.py tests/test_BuildStockUtility.py (50 passed live with Athena)